### PR TITLE
fix: install.sh の git リンク先を XDG 準拠パスに修正

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -58,7 +58,7 @@ link_file "$DOTFILES_DIR/zsh/.zshrc"              "$HOME_DIR/.zshrc"
 link_file "$DOTFILES_DIR/zsh/.zsh.d"              "$HOME_DIR/.zsh.d"
 
 # Git
-link_file "$DOTFILES_DIR/git/.gitconfig"         "$HOME_DIR/.gitconfig"
+link_file "$DOTFILES_DIR/git/.config/git/config"  "$HOME_DIR/.config/git/config"
 
 # WezTerm
 link_file "$DOTFILES_DIR/wezterm/.wezterm.lua"      "$HOME_DIR/.wezterm.lua"


### PR DESCRIPTION
## Summary

- `git/.gitconfig → ~/.gitconfig` のリンクを `git/.config/git/config → ~/.config/git/config` に修正
- ソースファイルが存在しないため Skipping されていた問題を解消

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)