### PR TITLE
chore: 冗長な STARSHIP_CONFIG 設定を削除

### DIFF
--- a/zsh/.zsh.d/00_path.zsh
+++ b/zsh/.zsh.d/00_path.zsh
@@ -38,9 +38,6 @@ export LESSHISTFILE="$XDG_STATE_HOME/less/history"
 export PSQL_HISTORY="$XDG_STATE_HOME/psql/history"
 
 # --- その他の設定 ---
-# starship
-export STARSHIP_CONFIG="$HOME/.dotfiles/starship/.starship.toml"
-
 # Antigravity (XDG準拠のパス)
 export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/antigravity/antigravity/bin:$PATH"
 


### PR DESCRIPTION
## Summary

- `00_path.zsh` から `export STARSHIP_CONFIG=...` を削除
- `install.sh` が `~/.config/starship.toml` へシンボリックリンクを張っており、Starship はデフォルトでそのパスを参照するため不要

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)