### PR TITLE
fix: PYTHONSTARTUP の誤用を PYTHON_HISTORY に修正

### DIFF
--- a/zsh/.zsh.d/00_path.zsh
+++ b/zsh/.zsh.d/00_path.zsh
@@ -33,7 +33,7 @@ export DOCKER_CONFIG="$XDG_CONFIG_HOME/docker"
 export GNUPGHOME="$XDG_DATA_HOME/gnupg"
 export IPYTHONDIR="$XDG_CONFIG_HOME/ipython"
 export MPLCONFIGDIR="$XDG_CONFIG_HOME/matplotlib"
-export PYTHONSTARTUP="$XDG_CONFIG_HOME/python/history"
+export PYTHON_HISTORY="$XDG_STATE_HOME/python/history"
 export LESSHISTFILE="$XDG_STATE_HOME/less/history"
 export PSQL_HISTORY="$XDG_STATE_HOME/psql/history"
 


### PR DESCRIPTION
## Summary

- `PYTHONSTARTUP` を `PYTHON_HISTORY` に変更（Python 3.13+）
- パスを `XDG_CONFIG_HOME` から `XDG_STATE_HOME` 配下に変更（状態ファイルとして適切）

Closes #6

🤖 Generated with [Claude Code](https://claude.com/claude-code)