### PR TITLE
feat: zsh-autosuggestions を sheldon に追加

### DIFF
--- a/sheldon/plugins.toml
+++ b/sheldon/plugins.toml
@@ -29,3 +29,8 @@ apply = ["defer"]
 # カッコなどのペア補完
 github = "hlissner/zsh-autopair"
 apply = ["defer"]
+
+[plugins.zsh-autosuggestions]
+# 履歴ベースのコマンドサジェスト
+github = "zsh-users/zsh-autosuggestions"
+apply = ["defer"]


### PR DESCRIPTION
## Summary

- `sheldon/plugins.toml` に `zsh-autosuggestions` を追加
- 遅延読み込み（`zsh-defer`）で他プラグインと同様に設定

## 反映方法

マージ後、シェルを再起動するか以下を実行する。

```bash
sheldon lock --update
```

Closes #7

🤖 Generated with [Claude Code](https://claude.com/claude-code)