### PR TITLE
chore: newsboat/urls を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ git/.config/git/local
 
 # Neovim プラグインロックファイル（常に最新バージョンを使う方針）
 nvim/lazy-lock.json
+
+# newsboat フィード URL（個人の購読リストのため除外）
+newsboat/urls

--- a/newsboat/urls
+++ b/newsboat/urls
@@ -1,5 +1,0 @@
-http://feeds.seroundtable.com/SearchEngineRoundtable1 Search Engine Roundtable
-https://www.suzukikenichi.com/blog/feed/              海外SEO情報ブログ
-https://searchengineland.com/feed                     Search Engine Land
-https://rss.searchenginejournal.com/                  Search Engine Journal
-https://feeds.feedburner.com/blogspot/amDG            Google Search Central Blog

--- a/newsboat/urls.example
+++ b/newsboat/urls.example
@@ -1,0 +1,5 @@
+# newsboat フィード URL リスト
+# このファイルを urls にコピーして使用する
+# フォーマット: <URL> [タグ] ["フィード名"]
+#
+# https://feedurl.example/feed  tag1 tag2 "Feed Name"


### PR DESCRIPTION
## Summary

- `newsboat/urls` を `.gitignore` に追加し、追跡を停止
- `newsboat/urls.example` をテンプレートとしてコミット

## セットアップ時の手順

```bash
cp ~/.dotfiles/newsboat/urls.example ~/.dotfiles/newsboat/urls
# urls を編集してフィードを追加
```

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)