### PR TITLE
fix: eza の tab 補完が動作しない問題を修正

### DIFF
--- a/zsh/.zsh.d/00_path.zsh
+++ b/zsh/.zsh.d/00_path.zsh
@@ -37,6 +37,10 @@ export PYTHON_HISTORY="$XDG_STATE_HOME/python/history"
 export LESSHISTFILE="$XDG_STATE_HOME/less/history"
 export PSQL_HISTORY="$XDG_STATE_HOME/psql/history"
 
+# --- Zsh 補完パス ---
+# Homebrew の補完ファイル（eza など）を compinit より前に登録
+fpath=(/opt/homebrew/share/zsh/site-functions $fpath)
+
 # --- その他の設定 ---
 # Antigravity (XDG準拠のパス)
 export PATH="${XDG_DATA_HOME:-$HOME/.local/share}/antigravity/antigravity/bin:$PATH"


### PR DESCRIPTION
## Summary

- `compinit` の前に `/opt/homebrew/share/zsh/site-functions` を `fpath` へ追加
- これにより `eza` などの Homebrew 製ツールの補完が正しく読み込まれる

Closes #24

## Test plan

- [ ] 新しいシェルセッションで `eza --<Tab>` を入力し補完候補が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)