### PR TITLE
feat: github-issue スキルと Issue テンプレートを追加する

### DIFF
--- a/claude/skills/github-issue-comment/SKILL.md
+++ b/claude/skills/github-issue-comment/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: github-issue-comment
+description: git push 後に、ブランチ名から関連する GitHub Issue を特定してコメントを追加する。push したが作業が完了していない場合に使用する。
+user-invocable: true
+allowed-tools: Bash
+---
+
+# GitHub Issue コメントスキル
+
+`git push` を実行した後、作業が完了していない場合に関連 Issue へ進捗コメントを追加する。
+
+## Issue 番号の特定
+
+ブランチ名から Issue 番号を抽出する：
+
+```bash
+git branch --show-current
+```
+
+ブランチ名の命名規則: `<type>/issue-<番号>-<説明>`
+例: `feat/issue-26-claude-skills` → Issue #26
+
+## 手順
+
+1. 現在のブランチ名を取得し、`issue-{番号}` の部分から Issue 番号を特定する
+2. 直近の push 内容（コミットメッセージ・変更ファイル）を確認する：
+   ```bash
+   git log -1 --pretty=format:"%s" 
+   git diff HEAD~1 --name-only
+   ```
+3. 以下の形式でコメントを作成する：
+   ```bash
+   gh issue comment <番号> --body "$(cat <<'EOF'
+   ## 作業ログ
+
+   ### 実施内容
+   - 
+
+   ### 変更ファイル
+   - 
+
+   ### 次のステップ
+   - 
+   EOF
+   )"
+   ```
+
+## 注意事項
+
+- ブランチ名に `issue-{番号}` が含まれない場合はユーザーに Issue 番号を確認する
+- コメントは簡潔に。変更の「何をしたか」と「次に何をするか」を明記する
+- 作業が完了した場合はこのスキルを使わず、`github-pr` スキルで PR を作成してクローズする

--- a/claude/skills/github-issue-create/SKILL.md
+++ b/claude/skills/github-issue-create/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: github-issue-create
+description: GitHub Issue をテンプレートを使って作成する。Issue 作成を依頼されたときに使用する。
+user-invocable: true
+allowed-tools: Bash, Read, Glob
+---
+
+# GitHub Issue 作成スキル
+
+GitHub Issue をプロジェクトのテンプレートに基づいて作成する。
+
+## ラベル一覧
+
+| ラベル | 用途 |
+|---|---|
+| `feat` | 新機能・機能追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメント |
+| `chore` | 保守・依存関係更新などの雑務 |
+| `refactor` | リファクタリング |
+| `ci` | CI/CD 関連 |
+| `idea` | アイデア・提案 |
+| `research` | 技術調査・検証 |
+
+## テンプレート選択ルール
+
+内容に応じて以下のテンプレートを選択する：
+
+- **bug_report**: エラー・不具合の報告
+- **feature**: 開発タスク・機能追加・改善（デフォルト）
+- **research**: 技術調査・検証
+
+## 手順
+
+1. ユーザーの依頼内容からテンプレートとラベルを判断する
+2. プロジェクトの `.github/ISSUE_TEMPLATE/` にテンプレートが存在するか確認する
+3. テンプレートの内容をユーザーの依頼内容で埋める
+4. 以下のコマンドで Issue を作成する：
+
+```bash
+gh issue create \
+  --title "タイトル" \
+  --label "ラベル" \
+  --assignee "ksip9012" \
+  --body "$(cat <<'EOF'
+テンプレートの本文
+EOF
+)"
+```
+
+5. 作成された Issue の URL をユーザーに伝える
+
+## 注意事項
+
+- assignees は常に `ksip9012` を設定する
+- ラベルが存在しない場合は作成してから Issue を作成する：
+  ```bash
+  gh label create "ラベル名" --color "カラーコード" --description "説明"
+  ```
+- タイトルはテンプレートの `title` プレフィックスに従う（例：`[fix] `, `[research] `）
+
+## ラベルのカラーコード
+
+| ラベル | カラー |
+|---|---|
+| `feat` | `#0075ca` |
+| `fix` | `#d73a4a` |
+| `docs` | `#0075ca` |
+| `chore` | `#e4e669` |
+| `refactor` | `#a2eeef` |
+| `ci` | `#f9d0c4` |
+| `idea` | `#d876e3` |
+| `research` | `#fbca04` |

--- a/github/ISSUE_TEMPLATE/bug_report.md
+++ b/github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug Report
+about: 問題やエラーの報告
+title: '[fix] '
+labels: fix
+assignees: 'ksip9012'
+---
+
+## 🚨 発生している問題 / Describe the bug
+
+## 🛠 再現手順 / To Reproduce
+
+1.
+2.
+3.
+
+## 📋 期待される動作 / Expected behavior
+
+## 💻 環境 / Environment
+
+- OS: [e.g. macOS / Windows]
+- 関連するファイル/モジュール:
+
+## 📝 備考 / Notes

--- a/github/ISSUE_TEMPLATE/feature.md
+++ b/github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,20 @@
+---
+name: Feature / Task
+about: 開発タスクや改善案のテンプレート
+title: ''
+labels: feat
+assignees: 'ksip9012'
+---
+
+## 🚀 目的 / Context
+
+## 🛠 やること / Tasks
+
+- [ ]
+- [ ]
+
+## ✅ 完了条件 / Definition of Done
+
+- [ ]
+
+## 📝 備考 / Notes

--- a/github/ISSUE_TEMPLATE/research.md
+++ b/github/ISSUE_TEMPLATE/research.md
@@ -1,0 +1,15 @@
+---
+name: Research / Investigation
+about: 技術的な調査や検証
+title: '[research] '
+labels: research
+assignees: 'ksip9012'
+---
+
+## 🔍 調査対象 / Topic
+
+## 🎯 目的 / Objective
+
+## 📝 調査ログ / Investigation Log
+
+## 💡 結論・次のアクション / Conclusion & Next Steps


### PR DESCRIPTION
## Summary

- `github/ISSUE_TEMPLATE/` に汎用 Issue テンプレート3種を追加
  - `bug_report.md` — バグ報告（seo-ai-pipeline から汎用化）
  - `feature.md` — 開発タスク・機能追加
  - `research.md` — 技術調査・検証
- `github-issue-create` スキルを追加
  - テンプレート・ラベルを使った Issue 作成
  - assignees は常に `ksip9012`
  - ラベル8種（feat / fix / docs / chore / refactor / ci / idea / research）
- `github-issue-comment` スキルを追加
  - push 後にブランチ名（`issue-{番号}`）から Issue を特定してコメント追加

## Test plan

- [ ] `/github-issue-create` で Issue が作成されることを確認
- [ ] `/github-issue-comment` でブランチ名から Issue 番号が特定されコメントされることを確認
- [ ] テンプレートが `.github/ISSUE_TEMPLATE/` にコピーされた場合に GitHub 上で選択できることを確認

Closes #28 (github-issue 部分)

🤖 Generated with [Claude Code](https://claude.com/claude-code)