### PR TITLE
feat: github-branch スキルと GitHub 運用ルールを追加する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,3 +51,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Python コーディング規約
 
 Ruff の設定により行長は **79文字**（`nvim/lua/lsp/init.lua` の `lineLength` 設定）。
+
+## GitHub 運用ルール
+
+### ブランチ戦略
+
+GitHub Flow を採用。常に `main` からブランチを切り、PR 経由でマージする。
+
+### ブランチ作成
+
+**Issue への取り組みを開始する前に、必ず `github-branch` スキルでブランチを作成する。**
+
+命名規則: `<type>/issue-<番号>-<簡潔な説明>`
+例: `feat/issue-32-github-branch-skill`
+
+type は `feat` / `fix` / `docs` / `chore` / `refactor` / `ci` / `idea` / `research` から選ぶ。

--- a/claude/skills/github-branch/SKILL.md
+++ b/claude/skills/github-branch/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: github-branch
+description: Issue に取り組む際に GitHub Flow に基づいてブランチを作成する。Issue 番号からブランチ名を自動生成し、main を最新化してからブランチを切る。
+user-invocable: true
+allowed-tools: Bash
+---
+
+# ブランチ作成スキル
+
+Issue への取り組みを開始するときに呼び出す。GitHub Flow に基づき、常に `main` から作業ブランチを切る。
+
+## ブランチ命名規則
+
+```
+<type>/issue-<番号>-<簡潔な説明>
+```
+
+例: `feat/issue-32-github-branch-skill`
+
+### type 一覧
+
+| type | 用途 |
+|---|---|
+| `feat` | 新機能・機能追加 |
+| `fix` | バグ修正 |
+| `docs` | ドキュメント |
+| `chore` | 保守・依存関係更新などの雑務 |
+| `refactor` | リファクタリング |
+| `ci` | CI/CD 関連 |
+| `idea` | アイデア・提案 |
+| `research` | 技術調査・検証 |
+
+## 手順
+
+### 1. Issue 情報の取得
+
+Issue 番号が指定されている場合はそこから取得する：
+
+```bash
+gh issue view <番号> --json title,labels
+```
+
+指定がない場合はユーザーに Issue 番号を確認する。
+
+### 2. type の判定
+
+Issue のラベルから type を決定する。ラベルが未設定の場合は Issue タイトル・内容から判断する。
+
+### 3. ブランチ名の生成
+
+- Issue タイトルをもとに簡潔な英語スラッグを生成（スペース→ハイフン、小文字）
+- 最終的なブランチ名をユーザーに提示して確認を取る
+
+### 4. ブランチの作成
+
+```bash
+git checkout main
+git pull origin main
+git checkout -b <branch-name>
+```
+
+### 5. 完了報告
+
+作成したブランチ名をユーザーに伝える。
+
+## 注意事項
+
+- リモートへの push はこのスキルでは行わない（作業後の最初の push に委ねる）
+- 未コミットの変更がある場合は事前に `git stash` するか、ユーザーに確認する
+- ブランチ名の説明部分は短く（3〜5単語程度）、内容が伝わるものにする


### PR DESCRIPTION
## Summary

- `github-branch` スキルを追加
  - Issue 番号・ラベルからブランチ名（`<type>/issue-<番号>-<説明>`）を自動生成
  - `main` を最新化してからブランチを作成
  - リモート push は作業後の最初の push に委ねる
- `CLAUDE.md` に GitHub 運用ルールを追記
  - GitHub Flow 採用の明示
  - Issue 着手前の `github-branch` スキル使用を必須化

## Test plan

- [ ] Issue 番号を指定して `/github-branch` を呼び出し、正しい命名のブランチが作成されることを確認
- [ ] `main` が最新化されてからブランチが切られることを確認

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)