### PR TITLE
chore: nvim と wezterm の設定を更新する

### DIFF
--- a/nvim/init.lua
+++ b/nvim/init.lua
@@ -1,6 +1,10 @@
 -- Leader key
 vim.g.mapleader = ' '
 
+-- nvim-tree: netrw を無効化（競合防止のため plugins より前に設定）
+vim.g.loaded_netrw       = 1
+vim.g.loaded_netrwPlugin = 1
+
 -- Core settings
 require('core.options')
 require('core.keymaps')

--- a/nvim/lua/core/keymaps.lua
+++ b/nvim/lua/core/keymaps.lua
@@ -27,6 +27,19 @@ map('n', '<leader>d', '<cmd>lua vim.diagnostic.open_float()<CR>', {desc = 'Show 
 map('n', '[d', '<cmd>lua vim.diagnostic.goto_prev()<CR>', {desc = 'Prev diagnostic'})
 map('n', ']d', '<cmd>lua vim.diagnostic.goto_next()<CR>', {desc = 'Next diagnostic'})
 
+-- GTD
+local gtd = vim.fn.expand('~/Documents/life/gtd/')
+map('n', '<leader>zi', function() vim.cmd('e ' .. gtd .. '001_inbox.md') end,        {desc = 'GTD: Inbox'})
+map('n', '<leader>zt', function() vim.cmd('e ' .. gtd .. '004_todo.md') end,         {desc = 'GTD: Todo'})
+map('n', '<leader>zw', function() vim.cmd('e ' .. gtd .. '007_waiting_for.md') end,  {desc = 'GTD: Waiting'})
+map('n', '<leader>zs', function() vim.cmd('e ' .. gtd .. '006_someday_maybe.md') end,{desc = 'GTD: Someday'})
+map('n', '<leader>zp', function()
+  require('telescope.builtin').find_files({ cwd = gtd .. '002_project/' })
+end, {desc = 'GTD: Projects'})
+map('n', '<leader>z/', function()
+  require('telescope.builtin').live_grep({ cwd = vim.fn.expand('~/Documents/life/') })
+end, {desc = 'GTD: Grep all'})
+
 -- which-key グループラベル
 local ok, wk = pcall(require, 'which-key')
 if ok then
@@ -34,5 +47,6 @@ if ok then
     { '<leader>h', group = 'Git hunk' },
     { '<leader>f', group = 'Telescope' },
     { '<leader>g', group = 'Git' },
+    { '<leader>z', group = 'GTD' },
   })
 end

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -11,7 +11,52 @@ require('lazy').setup({
   {
     'nvim-tree/nvim-tree.lua',
     dependencies = {'nvim-tree/nvim-web-devicons'},
-    config = function() require('nvim-tree').setup() end,
+    config = function()
+      require('nvim-tree').setup({
+        update_focused_file = { enable = true },
+        git = { enable = true, ignore = false },
+        renderer = {
+          indent_markers = { enable = true },
+        },
+      })
+
+      local function hide_cursor()
+        local cursorline_hl = vim.api.nvim_get_hl(0, { name = 'CursorLine', link = false })
+        local normal_hl     = vim.api.nvim_get_hl(0, { name = 'Normal',     link = false })
+        local hl_options = {}
+        if cursorline_hl.bg then hl_options.bg = cursorline_hl.bg end
+        if normal_hl.fg     then hl_options.fg = normal_hl.fg     end
+        if next(hl_options) == nil then return end
+
+        vim.api.nvim_set_hl(0, 'NvimTreeCursorInvisible', hl_options)
+        local parts = {}
+        for setting in string.gmatch(vim.api.nvim_get_option_value('guicursor', { scope = 'global' }), '[^,]+') do
+          local mode_prefix, _ = setting:match('^([%w%-]+):(.+)$')
+          if mode_prefix and mode_prefix:find('n') then
+            table.insert(parts, mode_prefix .. ':ver01-NvimTreeCursorInvisible')
+          else
+            table.insert(parts, setting)
+          end
+        end
+        vim.api.nvim_set_option_value('guicursor', table.concat(parts, ','), { scope = 'local' })
+      end
+
+      local function show_cursor()
+        vim.api.nvim_set_option_value(
+          'guicursor',
+          vim.api.nvim_get_option_value('guicursor', { scope = 'global' }),
+          { scope = 'local' }
+        )
+      end
+
+      local group = vim.api.nvim_create_augroup('NvimTreeCursor', { clear = true })
+      vim.api.nvim_create_autocmd('BufEnter', {
+        group = group, pattern = 'NvimTree_*', callback = hide_cursor,
+      })
+      vim.api.nvim_create_autocmd('BufLeave', {
+        group = group, pattern = 'NvimTree_*', callback = show_cursor,
+      })
+    end,
   },
   {
     'nvim-telescope/telescope.nvim',

--- a/wezterm/.wezterm.lua
+++ b/wezterm/.wezterm.lua
@@ -92,6 +92,19 @@ config.cell_width = 0.90
 -- 行間の調整
 config.line_height = 0.95
 
+-- アクティブペインを目立たせる
+config.inactive_pane_hsb = {
+  saturation = 0.7,
+  brightness = 0.6,
+}
+
+-- タブバーに時計を表示
+wezterm.on('update-right-status', function(window, _)
+  window:set_right_status(wezterm.format({
+    { Text = wezterm.strftime(' %Y-%m-%d %H:%M ') },
+  }))
+end)
+
 -- スクロールバック行数
 config.scrollback_lines = 10000
 


### PR DESCRIPTION
## Summary

- nvim: netrw を無効化（nvim-tree との競合防止）
- nvim: GTD ファイルへのキーマップを追加（`<leader>z*`）
- nvim: nvim-tree の設定強化・カーソル非表示 autocmd を追加
- wezterm: 非アクティブペインの輝度調整を追加
- wezterm: タブバー右側に時計を表示

## Related Issue

なし（既存の未コミット変更を整理）

## Test plan

- [ ] nvim 起動時に nvim-tree が正常に動作することを確認
- [ ] `<leader>zi` で GTD Inbox が開くことを確認
- [ ] wezterm で非アクティブペインが暗くなることを確認
- [ ] タブバー右側に時計が表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)