### PR TITLE
fix: Issue 作成時の assignee・label 設定漏れをグローバルルールに追記する

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -19,6 +19,12 @@ GitHub Flow を採用。常に `main` からブランチを切り、PR 経由で
 
 type は `feat` / `fix` / `docs` / `chore` / `refactor` / `ci` / `idea` / `research` から選ぶ。
 
+### Issue 作成
+
+**Issue 作成時は必ず以下を設定する：**
+- `--assignee ksip9012`
+- `--label <内容に対応するラベル>`
+
 ### PR 作成
 
 **PR 作成時は必ず以下を設定する：**


### PR DESCRIPTION
## Summary

- グローバル `claude/CLAUDE.md` に Issue 作成時の必須設定を追記
  - `--assignee ksip9012` と `--label` を常に設定するルールを明文化

## Related Issue

Closes #39

## Test plan

- [ ] 次回 Issue 作成時に assignee と label が付与されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)