### PR TITLE
fix: git push 後に github-issue-comment を自動呼び出しするルールを追記する

### DIFF
--- a/claude/CLAUDE.md
+++ b/claude/CLAUDE.md
@@ -25,6 +25,10 @@ type は `feat` / `fix` / `docs` / `chore` / `refactor` / `ci` / `idea` / `resea
 - `--assignee ksip9012`
 - `--label <内容に対応するラベル>`
 
+### git push 後のコメント
+
+`git push` を実行した後、その Issue の作業が**完了していない**場合は必ず `github-issue-comment` スキルを呼び出してコメントを追記する。作業が完了した場合は `github-pr` スキルで PR を作成する。
+
 ### PR 作成
 
 **PR 作成時は必ず以下を設定する：**


### PR DESCRIPTION
## Summary

- グローバル `claude/CLAUDE.md` に push 後の自動コメントルールを追記
  - 作業未完了 → `github-issue-comment` スキルを呼び出してコメント追記
  - 作業完了 → `github-pr` スキルで PR を作成

## Related Issue

Closes #41

## Test plan

- [ ] git push 後、作業未完了の場合に自動で Issue へコメントが追加されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)