### PR TITLE
docs: Brewfile に用途コメントとセクション分けを追加する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -1,43 +1,91 @@
-brew "bat"
-brew "bottom"
-brew "coreutils"
-brew "tree-sitter"
-brew "cask"
-brew "docker"
-brew "docker-compose"
-brew "dust"
-brew "eza"
-brew "fd"
-brew "fzf"
-brew "gawk"
-brew "git-delta"
-brew "icu4c@78"
-brew "node"
-brew "gemini-cli"
-brew "gh"
-brew "git"
-brew "gnupg"
-brew "pkgconf"
-brew "lilypond"
-brew "mise"
-brew "neovim"
-brew "procs"
-brew "ripgrep"
-brew "rm-improved"
-brew "sd"
-brew "sheldon"
-brew "sqruff"
-brew "starship"
-brew "tree"
-brew "tree-sitter-cli"
-brew "xh"
-brew "zoxide"
-cask "antigravity"
-cask "blender"
-cask "claude-code"
-cask "cursor"
-cask "dbeaver-community"
-cask "discord"
+# ── CLI tools ──────────────────────────────────────────────────────────────
+brew "bat"          # cat 代替：シンタックスハイライト付きファイル表示
+brew "bottom"       # top 代替：CPU/メモリ/ネットワークをグラフ表示
+brew "coreutils"    # GNU コアユーティリティ（gls, gdate など）
+brew "tree-sitter"  # 構文解析ライブラリ（Neovim 依存）
+brew "dust"         # du 代替：ディスク使用量をツリー表示
+brew "eza"          # ls 代替：アイコン・git 情報付きリスト表示
+brew "fd"           # find 代替：高速ファイル検索
+brew "fzf"          # ファジーファインダー（インタラクティブ絞り込み）
+brew "gawk"         # AWK の GNU 実装（スクリプト用）
+brew "git-delta"    # git diff の syntax highlighter
+brew "procs"        # ps 代替：カラー付きプロセス一覧
+brew "ripgrep"      # grep 代替：高速全文検索（fzf・Neovim Telescope と連携）
+brew "rm-improved"  # rm 代替：削除ファイルをゴミ箱に送り復元可能にする
+brew "sd"           # sed 代替：直感的な文字列置換
+brew "tree"         # ディレクトリツリー表示
+brew "xh"           # curl 代替：HTTP リクエストクライアント
+brew "zoxide"       # cd 代替：履歴ベースのスマートディレクトリ移動
+
+# ── Shell / Prompt ─────────────────────────────────────────────────────────
+brew "sheldon"      # zsh プラグインマネージャ
+brew "starship"     # クロスシェル対応プロンプト
+
+# ── Runtime / Package manager ──────────────────────────────────────────────
+brew "mise"         # Python/Node.js/Poetry などランタイムバージョン管理
+brew "node"         # Node.js（mise 管理外のグローバルツール用）
+
+# ── Editor ─────────────────────────────────────────────────────────────────
+brew "neovim"       # テキストエディタ
+
+# ── Git / GitHub ───────────────────────────────────────────────────────────
+brew "git"          # バージョン管理
+brew "gh"           # GitHub CLI
+
+# ── Container ──────────────────────────────────────────────────────────────
+brew "docker"       # コンテナランタイム
+brew "docker-compose" # マルチコンテナ定義・実行
+
+# ── SQL ────────────────────────────────────────────────────────────────────
+brew "sqruff"       # SQL リンター（CLI）
+
+# ── AI / Dev tools ─────────────────────────────────────────────────────────
+brew "gemini-cli"   # Google Gemini CLI
+
+# ── Security ───────────────────────────────────────────────────────────────
+brew "gnupg"        # GPG 署名・暗号化
+
+# ── Build dependencies ─────────────────────────────────────────────────────
+brew "pkgconf"      # pkg-config 代替（ライブラリビルド依存）
+brew "icu4c@78"     # Unicode/国際化ライブラリ（各種ツール依存）
+brew "tree-sitter-cli" # Tree-sitter 文法ファイル生成 CLI
+
+# ── Music notation ─────────────────────────────────────────────────────────
+brew "lilypond"     # 楽譜作成ツール
+
+# ── Apps ───────────────────────────────────────────────────────────────────
+brew "cask"         # Homebrew Cask 本体
+
+# ── Cask: Development ──────────────────────────────────────────────────────
+cask "claude-code"         # Anthropic Claude Code デスクトップアプリ
+cask "cursor"              # AI 統合エディタ
+cask "visual-studio-code"  # コードエディタ
+cask "zed"                 # 高速コードエディタ
+cask "wezterm"             # GPU アクセラレーション対応ターミナル
+cask "fork"                # Git GUI クライアント
+cask "dbeaver-community"   # DB ユニバーサルクライアント
+cask "gcloud-cli"          # Google Cloud SDK
+
+# ── Cask: Productivity ─────────────────────────────────────────────────────
+cask "raycast"      # ランチャー・ワークフロー自動化
+cask "notion"       # ドキュメント・ナレッジベース
+cask "obsidian"     # マークダウンベースのノートアプリ
+cask "todoist-app"  # タスク管理
+cask "macpass"      # KeePass 互換パスワードマネージャ
+
+# ── Cask: Communication ────────────────────────────────────────────────────
+cask "slack"        # チームチャット
+cask "discord"      # コミュニティチャット
+
+# ── Cask: Media / Creative ─────────────────────────────────────────────────
+cask "blender"      # 3D モデリング・アニメーション
+cask "spotify"      # 音楽ストリーミング
+cask "antigravity"  # スクリーンセーバー
+
+# ── Cask: Browser ──────────────────────────────────────────────────────────
+cask "google-chrome" # Web ブラウザ
+
+# ── Cask: Fonts ────────────────────────────────────────────────────────────
 cask "font-3270-nerd-font"
 cask "font-fira-code-nerd-font"
 cask "font-hackgen"
@@ -48,61 +96,59 @@ cask "font-jetbrains-mono"
 cask "font-meslo-lg-nerd-font"
 cask "font-monaspace"
 cask "font-terminess-ttf-nerd-font"
-cask "fork"
-cask "gcloud-cli"
-cask "google-chrome"
-cask "macpass"
-cask "notion"
-cask "obsidian"
-cask "raycast"
-cask "slack"
-cask "spotify"
-cask "todoist-app"
-cask "visual-studio-code"
-cask "wezterm"
-cask "zed"
+
+# ── VSCode Extensions ──────────────────────────────────────────────────────
+# -- General
 vscode "alexcvzz.vscode-sqlite"
-vscode "anthropic.claude-code"
 vscode "bierner.markdown-mermaid"
-vscode "charliermarsh.ruff"
 vscode "codezombiech.gitignore"
 vscode "davidanson.vscode-markdownlint"
 vscode "dbaeumer.vscode-eslint"
 vscode "esbenp.prettier-vscode"
-vscode "foam.foam-vscode"
-vscode "github.vscode-github-actions"
-vscode "google.gemini-cli-vscode-ide-companion"
 vscode "hediet.vscode-drawio"
 vscode "janisdd.vscode-edit-csv"
-vscode "jeandeaual.lilypond-syntax"
-vscode "jeandeaual.scheme"
 vscode "johnpapa.winteriscoming"
-vscode "kimlimjustin.jsdoc-generator"
-vscode "lhl2617.lilypond-formatter"
-vscode "lhl2617.lilypond-pdf-preview"
-vscode "lhl2617.lilypond-snippets"
-vscode "lhl2617.vslilypond"
 vscode "marp-team.marp-vscode"
 vscode "mechatroner.rainbow-csv"
 vscode "mhutchie.git-graph"
+vscode "oderwat.indent-rainbow"
+vscode "pkief.material-icon-theme"
+vscode "ritwickdey.liveserver"
+vscode "silofy.hackthebox"
+vscode "tamasfe.even-better-toml"
+vscode "usernamehw.errorlens"
+vscode "yzhang.markdown-all-in-one"
+vscode "yzane.markdown-pdf"
+vscode "takumii.markdowntable"
+# -- Python
+vscode "charliermarsh.ruff"
 vscode "ms-python.debugpy"
 vscode "ms-python.python"
 vscode "ms-python.vscode-pylance"
 vscode "ms-python.vscode-python-envs"
+vscode "njpwerner.autodocstring"
+# -- Jupyter
 vscode "ms-toolsai.jupyter"
 vscode "ms-toolsai.jupyter-keymap"
 vscode "ms-toolsai.jupyter-renderers"
 vscode "ms-toolsai.vscode-jupyter-cell-tags"
 vscode "ms-toolsai.vscode-jupyter-slideshow"
-vscode "njpwerner.autodocstring"
-vscode "oderwat.indent-rainbow"
-vscode "pkief.material-icon-theme"
+# -- SQL
 vscode "quary.sqruff"
-vscode "ritwickdey.liveserver"
 vscode "shinichi-takii.sql-bigquery"
-vscode "silofy.hackthebox"
-vscode "takumii.markdowntable"
-vscode "tamasfe.even-better-toml"
-vscode "usernamehw.errorlens"
-vscode "yzane.markdown-pdf"
-vscode "yzhang.markdown-all-in-one"
+# -- LilyPond
+vscode "jeandeaual.lilypond-syntax"
+vscode "lhl2617.lilypond-formatter"
+vscode "lhl2617.lilypond-pdf-preview"
+vscode "lhl2617.lilypond-snippets"
+vscode "lhl2617.vslilypond"
+# -- AI
+vscode "anthropic.claude-code"
+vscode "google.gemini-cli-vscode-ide-companion"
+# -- JavaScript
+vscode "kimlimjustin.jsdoc-generator"
+vscode "jeandeaual.scheme"
+# -- GitHub
+vscode "github.vscode-github-actions"
+# -- Foam (ナレッジグラフ)
+vscode "foam.foam-vscode"


### PR DESCRIPTION
## Summary

- 各 `brew` / `cask` エントリに用途コメントを追加
- CLI tools / Shell / Runtime / Git / Container / SQL / Security / Fonts / VSCode Extensions などのセクションに分類
- VSCode 拡張を言語・用途別（Python / Jupyter / SQL / LilyPond / AI など）にグループ化

## Related Issue

Closes #54

## Test plan

- [ ] `brew bundle install` がエラーなく通る
- [ ] コメントを読むだけで各ツールの用途が判断できる

🤖 Generated with [Claude Code](https://claude.com/claude-code)