### PR TITLE
feat: install.sh で git ローカル設定を自動生成する

### DIFF
--- a/git/.config/git/local.example
+++ b/git/.config/git/local.example
@@ -1,0 +1,3 @@
+[user]
+	name = Your Name
+	email = your@email.com

--- a/install.sh
+++ b/install.sh
@@ -105,6 +105,28 @@ link_file "$DOTFILES_DIR/claude/settings.json"     "$HOME_DIR/.claude/settings.j
 link_file "$DOTFILES_DIR/claude/CLAUDE.md"         "$HOME_DIR/.claude/CLAUDE.md"
 link_file "$DOTFILES_DIR/claude/skills"            "$HOME_DIR/.claude/skills"
 
+# --- Git local config setup ---
+GIT_LOCAL="$HOME_DIR/.config/git/local"
+GIT_LOCAL_EXAMPLE="$DOTFILES_DIR/git/.config/git/local.example"
+
+if [ ! -f "$GIT_LOCAL" ]; then
+    echo ""
+    echo "👤 Git のユーザー情報を設定します（~/.config/git/local を作成）..."
+    printf "  名前  (git user.name) : "
+    read -r git_name
+    printf "  メール (git user.email): "
+    read -r git_email
+
+    mkdir -p "$(dirname "$GIT_LOCAL")"
+    sed -e "s/Your Name/$git_name/" \
+        -e "s/your@email.com/$git_email/" \
+        "$GIT_LOCAL_EXAMPLE" > "$GIT_LOCAL"
+    echo "  ✅ ~/.config/git/local を作成しました。"
+else
+    echo ""
+    echo "👤 ~/.config/git/local はすでに存在します。スキップします。"
+fi
+
 # --- Visual Studio Code (macOS only) ---
 if [[ "$(uname)" == "Darwin" ]]; then
     VSCODE_USER_DIR="$HOME_DIR/Library/Application Support/Code/User"


### PR DESCRIPTION
## Summary

- `git/.config/git/local.example` を新規追加（name / email のプレースホルダーテンプレート）
- `install.sh` に git ローカル設定セットアップ処理を追加
  - `~/.config/git/local` が未作成の場合のみ実行
  - `user.name` と `user.email` を対話入力させ、テンプレートから生成
  - 既存ファイルがある場合はスキップ

## Related Issue

Closes #51

## Test plan

- [ ] `~/.config/git/local` を退避した状態で `./install.sh` を実行し、name/email 入力プロンプトが表示される
- [ ] 入力後に `~/.config/git/local` が正しく生成され、`git config user.name` で反映される
- [ ] `~/.config/git/local` が既に存在する場合はスキップされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)