### PR TITLE
feat: conform.nvim を追加して Lua・Markdown 等のフォーマッタを設定する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -13,6 +13,8 @@ brew "procs"        # ps 代替：カラー付きプロセス一覧
 brew "ripgrep"      # grep 代替：高速全文検索（fzf・Neovim Telescope と連携）
 brew "rm-improved"  # rm 代替：削除ファイルをゴミ箱に送り復元可能にする
 brew "sd"           # sed 代替：直感的な文字列置換
+brew "stylua"       # Lua フォーマッタ（Neovim conform.nvim 用）
+brew "prettier"     # JS/TS/Markdown/JSON/YAML/HTML/CSS フォーマッタ（Neovim conform.nvim 用）
 brew "tree"         # ディレクトリツリー表示
 brew "xh"           # curl 代替：HTTP リクエストクライアント
 brew "zoxide"       # cd 代替：履歴ベースのスマートディレクトリ移動

--- a/nvim/lua/plugins.lua
+++ b/nvim/lua/plugins.lua
@@ -149,6 +149,30 @@ require('lazy').setup({
 
   { 'windwp/nvim-autopairs', event = 'InsertEnter', config = function() require('nvim-autopairs').setup() end },
 
+  -- フォーマッタ (Python は Ruff LSP が担当するため除外)
+  {
+    'stevearc/conform.nvim',
+    event = 'BufWritePre',
+    config = function()
+      require('conform').setup({
+        formatters_by_ft = {
+          lua        = { 'stylua' },
+          markdown   = { 'prettier' },
+          javascript = { 'prettier' },
+          typescript = { 'prettier' },
+          json       = { 'prettier' },
+          yaml       = { 'prettier' },
+          html       = { 'prettier' },
+          css        = { 'prettier' },
+        },
+        format_on_save = {
+          timeout_ms   = 500,
+          lsp_fallback = false,
+        },
+      })
+    end,
+  },
+
   -- lazygit
   {
     'kdheepak/lazygit.nvim',


### PR DESCRIPTION
## Summary

- `conform.nvim` を `plugins.lua` に追加（`BufWritePre` で遅延ロード）
- 保存時自動フォーマットを以下の言語に設定
  | 言語 | フォーマッタ |
  |---|---|
  | Lua | stylua |
  | Markdown / JS / TS / JSON / YAML / HTML / CSS | prettier |
- Python の Ruff LSP フォーマット（`lsp/init.lua`）は変更なし・競合なし
- `Brewfile` に `stylua` と `prettier` を追加

## Related Issue

Closes #49

## Test plan

- [ ] `brew bundle install` で stylua・prettier がインストールされる
- [ ] Lua ファイル保存時に stylua でフォーマットされる
- [ ] Markdown ファイル保存時に prettier でフォーマットされる
- [ ] Python ファイルは引き続き Ruff でフォーマットされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)