### PR TITLE
chore: antigravity と cursor を Brewfile から削除する

### DIFF
--- a/Brewfile
+++ b/Brewfile
@@ -61,7 +61,6 @@ brew "cask"         # Homebrew Cask 本体
 
 # ── Cask: Development ──────────────────────────────────────────────────────
 cask "claude-code"         # Anthropic Claude Code デスクトップアプリ
-cask "cursor"              # AI 統合エディタ
 cask "visual-studio-code"  # コードエディタ
 cask "zed"                 # 高速コードエディタ
 cask "wezterm"             # GPU アクセラレーション対応ターミナル
@@ -83,7 +82,6 @@ cask "discord"      # コミュニティチャット
 # ── Cask: Media / Creative ─────────────────────────────────────────────────
 cask "blender"      # 3D モデリング・アニメーション
 cask "spotify"      # 音楽ストリーミング
-cask "antigravity"  # スクリーンセーバー
 
 # ── Cask: Browser ──────────────────────────────────────────────────────────
 cask "google-chrome" # Web ブラウザ


### PR DESCRIPTION
## Summary

- `cask "cursor"` を Brewfile から削除（VS Code・Zed・Claude Code でカバー済み）
- `cask "antigravity"` を Brewfile から削除（同上）

## Related Issue

Closes #71

## Test plan

- [ ] `ruby -c Brewfile` で構文エラーがないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)