### PR TITLE
fix: zed/settings.json のトレイリングコンマを修正する

### DIFF
--- a/zed/settings.json
+++ b/zed/settings.json
@@ -13,6 +13,6 @@
   "theme": {
     "mode": "system",
     "light": "One Light",
-    "dark": "One Dark",
-  },
+    "dark": "One Dark"
+  }
 }


### PR DESCRIPTION
## Summary

- `zed/settings.json` の `theme` オブジェクト内の `"dark"` 行末と、オブジェクト閉じ括弧後のトレイリングコンマを削除した

## Related Issue

Closes #75

## Test plan

- [x] `zed/settings.json` が JSONC として有効な形式になっている

🤖 Generated with [Claude Code](https://claude.com/claude-code)